### PR TITLE
Added fusionbox http.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,10 +1,11 @@
 setup.py
 fusionbox/__init__.py
-fusionbox/middleware.py
 fusionbox/behaviors.py
-fusionbox/tests.py
-fusionbox/models.py
+fusionbox/http.py
 fusionbox/mail.py
+fusionbox/middleware.py
+fusionbox/models.py
+fusionbox/tests.py
 fusionbox/templatetags
 fusionbox/templatetags/__init__.py
 fusionbox/templatetags/fusionbox_tags.py

--- a/fusionbox/http.py
+++ b/fusionbox/http.py
@@ -1,0 +1,4 @@
+from django.http import HttpResponseRedirect
+
+class HttpResponseSeeOther(HttpResponseRedirect):
+    status_code = 303


### PR DESCRIPTION
Extendes Django class `HttpResponseRedirect` with status code 303 to
conform with the w3 standard redirect after a POST request.
