### PR TITLE
Adding 3 new template filters into fusionbox.templatetags

### DIFF
--- a/fusionbox/templatetags/credit_card_filters.py
+++ b/fusionbox/templatetags/credit_card_filters.py
@@ -5,12 +5,24 @@ register = template.Library()
 @register.filter_function
 @template.defaultfilters.stringfilter
 def starred(cc_number, star_char=u'\u25cf'):
+    """
+    {{cc_number|starred:'x'}}
+
+    Outputs:
+        xxxx xxxx xxxx 1234
+    """
     value = '%s%s' % ((len(cc_number) - 4) * star_char, cc_number[-4:])
     return ' '.join([value[i:i+4] for i in range(0, len(value), 4)])
 
 @register.filter_function
 @template.defaultfilters.stringfilter
 def cc_company(cc_number):
+    """
+    {{cc_number|cc_company}}
+
+    Outputs:
+        DISCOVER
+    """
     import re
     cc_patterns = (
         (re.compile(r'^4[0-9]{12}(?:[0-9]{3})?$'), 'VISA'),

--- a/fusionbox/templatetags/fusionbox_tags.py
+++ b/fusionbox/templatetags/fusionbox_tags.py
@@ -157,6 +157,12 @@ class HighlightHereParentNode(HighlightHereNode):
 
 register.tag("highlight_here_parent", HighlightHereParentNode)
 
+@register.filter_function
+def attr(obj, arg1):
+    att, value = arg1.split("=")
+    obj.field.widget.attrs[att] = value
+    return obj
+
 @register.filter
 def json(a):
     return mark_safe(simplejson.dumps(a))


### PR DESCRIPTION
3 new filters, 2 of which deal with credit cards

starred:
optionally accepts an argument to "star out" a credit card number

cc_company:
takes a credit card number and outputs the company name
aka: 4111 1111 1111 111 spits out VISA

attr:
http://djangosnippets.org/snippets/729/
I found the attr filter useful for forms that were imported from third party apps.
