### PR TITLE
Added us_dollars and us_dollars_and_cents template filters.

### DIFF
--- a/fusionbox/templatetags/fusionbox_tags.py
+++ b/fusionbox/templatetags/fusionbox_tags.py
@@ -178,4 +178,37 @@ def currency(dollars):
     http://stackoverflow.com/a/2180209/1013960
     """
     dollars = float(dollars)
+
     return "$%s%s" % (intcomma(int(dollars)), ("%0.2f" % dollars)[-3:])
+
+
+@register.filter
+def us_dollars(value):
+    """
+    Returns the value formatted as whole US dollars.
+
+    Example:
+        if value = -20000
+        {{ value|us_dollars }} => - $20,000
+    """
+    sign = '- ' if value < 0 else ''
+    return '{sign}${value:,.0f}'.format(
+            sign=sign,
+            value=abs(value),
+            )
+
+
+@register.filter
+def us_dollars_and_cents(value):
+    """
+    Returns the value formatted as US dollars with cents.
+
+    Example:
+        if value = -20000.125
+        {{ value|us_dollars_and_cents }} => - $20,000.13
+    """
+    sign = '- ' if value < 0 else ''
+    return '{sign}${value:,.2f}'.format(
+            sign=sign,
+            value=abs(value),
+            )


### PR DESCRIPTION
There already seems to be a currency filter, but this doesn't handle negative dollar values very well (-20000 => $-20,000 when it should be -$20,000).  Added a filter for whole dollars as well as dollars with cents.
