### PR TITLE
use CSRF token instead of session id for uncaptcha token

### DIFF
--- a/fusionbox/forms/models.py
+++ b/fusionbox/forms/models.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.middleware.csrf import get_token
 
 import hashlib
 
@@ -6,7 +7,7 @@ class UncaptchaBase(object):
     def __init__(self, request, *args, **kwargs):
         super(UncaptchaBase, self).__init__(*args, **kwargs)
         hasher = hashlib.sha256()
-        hasher.update(request.session.session_key)
+        hasher.update(get_token(request))
         self.uncaptcha_value = hasher.hexdigest()
 
     def clean_uncaptcha(self):


### PR DESCRIPTION
Using the session id is giving me very weird results, it seems to be changing unexpectedly.

@aaronmerriam, is there a reason this used the session id?
