### PR TITLE
More json support, but a little magical.

### DIFF
--- a/fusionbox/templatetags/fusionbox_tags.py
+++ b/fusionbox/templatetags/fusionbox_tags.py
@@ -174,8 +174,8 @@ def attr(obj, arg1):
 def more_json(obj):
     if isinstance(obj, Decimal):
         return float(obj)
-    if hasattr(obj, 'to_json'):
-        return obj.to_json()
+    if hasattr(obj, 'to_dict'):
+        return obj.to_dict()
     raise TypeError("%r is not JSON serializable" % (obj,))
 
 


### PR DESCRIPTION
More json support

This adds support for generic json using a `to_json` method.  I'm using it to
encode a form so I can use it in javascript:

```
var tmpl = _chz.my_template({
  'member': {{ member_form|json }},
  'us_states': {{ us_states|json }}
  });
```

But this could be accomplished a different way:

```
var tmpl = _chz.my_template({
  'member': {{ member_form.to_json }},
  'us_states': {{ us_states|json }}
  });
```

But if you wanted to jsonify a dict that has objects in it, it might be nice to control the json output.

Open for discussion!
