### PR TITLE
Email as username

### DIFF
--- a/fusionbox/fix_user/models.py
+++ b/fusionbox/fix_user/models.py
@@ -46,6 +46,10 @@ UserChangeForm.base_fields['username'].help_text = _("Required. 255 characters o
 
 old_init = UserChangeForm.__init__
 def new_init(self, *args, **kwargs):
+    if args:
+        data = args[0]
+    else:
+        data = {}
     ret = old_init(self, *args, **kwargs)
     self.fields['email'].label = 'Username'
     self.fields['email'].max_length = 255
@@ -54,9 +58,22 @@ def new_init(self, *args, **kwargs):
     self.fields['email'].widget.attrs['maxlength'] = 254  # html
     self.fields['email'].widget.attrs['readonly'] = 'readonly'
     self.fields['email'].widget.attrs['disabled'] = 'disabled'
+
+    if data:
+        data[self['email'].name] = data[self['username'].name]
     return ret
 
 UserChangeForm.__init__ = new_init
+
+
+old_clean = UserChangeForm.clean
+def new_clean(self, *args, **kwargs):
+    ret = old_clean(self, *args, **kwargs)
+    if 'email' in self._errors:
+        del self._errors['email']
+    return ret
+
+UserChangeForm.clean = new_clean
 
 
 def copy_username_to_email(sender, instance, *args, **kwargs):


### PR DESCRIPTION
This is based on some bug reports from Paula.

Modifies `fix_user/models.py` to create more user-friendly forms.  The downside is that this is some pretty heavy monkey-patching.  The upside is that Paula will not buggy your admin/user forms ;-)

Here's the overview:
1. Renames `username.label` to "Email", and I updated the `help_text` to say "Must be a valid email".
2. Modifies the `email` field to be readonly and disabled, and gives it the label "Username", and added `help_text` to explain the situation to the user.
3. Added a signal to set `user.email` to `user.username` in `pre_save`.  So even if the _do_ send an email address, it will be ignored.

The reason the labels are swapped: django validates uniqueness on the `username` field, not the `email` field.  So it is more straightforward to have the user set the `username`, and just blindly assign that to the `email`.  But it _looks better_ if the user thinks they are doing the opposite.

So there you have it.
