### PR TITLE
Raise a `RuntimeWarning` if the `validate_redirects` management command is executed without the proper middleware installed

### DIFF
--- a/fusionbox/core/management/commands/validate_redirects.py
+++ b/fusionbox/core/management/commands/validate_redirects.py
@@ -3,6 +3,7 @@ Loads fusionbox.middleware.RedirectFallbackMiddleware to check for problems
 """
 
 import os.path
+import warnings
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -11,8 +12,14 @@ from fusionbox.middleware import RedirectFallbackMiddleware
 
 redirect_path = getattr(settings, 'REDIRECTS_DIRECTORY', os.path.join(settings.PROJECT_PATH, '..', 'redirects'))
 
+
 class Command(BaseCommand):
     help = "Loads all CSV redirect files in '{path}' and checks for problems".format(path=redirect_path)
 
     def handle(self, *args, **options):
+        if ('fusionbox.middleware.RedirectFallbackMiddleware' not in
+                settings.MIDDLEWARE_CLASSES):
+            warnings.warn(
+                'fusionbox.middleware.RedirectFallbackMiddleware is '
+                'not in settings.INSTALLED_APPS', RuntimeWarning)
         RedirectFallbackMiddleware(raise_errors=False)

--- a/fusionbox/core/tests/__init__.py
+++ b/fusionbox/core/tests/__init__.py
@@ -1,3 +1,4 @@
 from test_templatetags import *
 from test_behaviors import *
 from test_serializers import *
+from test_commands import *

--- a/fusionbox/core/tests/test_commands.py
+++ b/fusionbox/core/tests/test_commands.py
@@ -1,0 +1,29 @@
+import warnings
+from django.test import TestCase
+from django.test.utils import override_settings
+
+
+class RedirectFallbackMiddlewareTests(TestCase):
+
+    @override_settings(MIDDLEWARE_CLASSES=tuple())
+    def test_raise_warning(self):
+        from fusionbox.core.management.commands.validate_redirects import (
+            Command as ValidateRedirectsCommand
+        )
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            ValidateRedirectsCommand().handle()
+            assert len(w) == 1
+            assert issubclass(w[-1].category, RuntimeWarning)
+
+    @override_settings(MIDDLEWARE_CLASSES=('fusionbox.middleware.RedirectFallbackMiddleware',))
+    def test_dont_raise_warning(self):
+        from fusionbox.core.management.commands.validate_redirects import (
+            Command as ValidateRedirectsCommand
+        )
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            ValidateRedirectsCommand().handle()
+            assert len(w) == 0


### PR DESCRIPTION
Also, add a `test_commands` module to cover the new feature
