### PR TITLE
MultiFileField should return an empty list by default.

### DIFF
--- a/fusionbox/forms/fields.py
+++ b/fusionbox/forms/fields.py
@@ -82,7 +82,7 @@ class MultiFileField(forms.FileField):
                     initial=initial)
             return map(curry_super, data)
         except TypeError:
-            return None
+            return []
 
 
 class UncaptchaWidget(forms.HiddenInput):


### PR DESCRIPTION
Before, it would return either a list of UploadedFiles or None.
However, this makes it harder to iterate over the results, for example,
the following line (taken from the docstring) fails if no files are
submitted:

```
for media_file in form.cleaned_data['field_name']:
    MyMedia.objects.create(
        name=media_file.name,
        file=media_file,
    )
```

Will result in a "TypeError: 'NoneType' object is not iterable".  If you
return an empty list instead, the code example won't fail if no files
are submitted.

cc @chroto 
