### PR TITLE
Refactor of ChangeList form classes.

### DIFF
--- a/fusionbox/behaviors.py
+++ b/fusionbox/behaviors.py
@@ -280,7 +280,7 @@ class Timestampable(Behavior):
     class Meta:
         abstract = True
 
-    created_at = models.DateTimeField(default=now, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
 


### PR DESCRIPTION
Backwards incompatible refactor of `SortForm` and `SearchForm` and removal of `FilterForm`.
- Remove `pre_sort`, `pre_search`, `post_sort`, `post_search` hooks.
- Refactor the `SortForm.headers`.  Less spagetti code and much easier to understand.
- Removed `FilterForm`.  After trying to rewrite this in a _sane_ manner I could not figure out a way to do what this form attempts to do in a way that didn't suck.

I don't think this pull should necessarily be directly merged.  Any project using these forms will likely need minor modifications due to the backwards incompatibilities.  Same with template code that references the headers.  Feedback?
