### PR TITLE
Fix for bug in highlighthere

### DIFF
--- a/fusionbox/core/templatetags/fusionbox_tags.py
+++ b/fusionbox/core/templatetags/fusionbox_tags.py
@@ -37,8 +37,7 @@ register = template.Library()
 
 
 def addclass(elem, cls):
-    elem['class'] = elem.get('class', '')
-    elem['class'] += ' ' + cls if elem['class'] else cls
+    elem['class'] = elem.get('class', []) + [cls]
 
 
 def is_here(current, url):


### PR DESCRIPTION
elem['class'] returns a list, not a string.