### PR TITLE
Support non-required CCExpirationDateField

### DIFF
--- a/fusionbox/forms/fields.py
+++ b/fusionbox/forms/fields.py
@@ -228,7 +228,8 @@ class CCExpirationDateField(forms.CharField):
                 raise forms.ValidationError(self.error_messages['expired'])
 
             return CCExpirationDateField.MonthYear(month, year)
-
+        elif self.required == False and value == '':
+            return None
         else:
             raise forms.ValidationError(self.error_messages['invalid'])
 

--- a/fusionbox/forms/fields.py
+++ b/fusionbox/forms/fields.py
@@ -228,7 +228,7 @@ class CCExpirationDateField(forms.CharField):
                 raise forms.ValidationError(self.error_messages['expired'])
 
             return CCExpirationDateField.MonthYear(month, year)
-        elif self.required == False and value == '':
+        elif not self.required and value == '':
             return None
         else:
             raise forms.ValidationError(self.error_messages['invalid'])


### PR DESCRIPTION
With this fix, a CCExpirationDateField can validate correctly if it isn't required.

I think returning `None` is the right behavior here? Not 100% confident.